### PR TITLE
added appveyor.yml CI buildup script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+
+# prepare environment
+environment:
+    matrix:
+    - python: C:\Python27;C:\Python27\Scripts
+    - python: C:\Python27-x64;C:\Python27-x64\Scripts
+    - python: C:\Python34;C:\Python34\Scripts
+    - python: C:\Python34-x64;C:\Python34-x64\Scripts
+
+build_script:
+# add location of used Python to path
+- set path=%path%;%python%
+- set PYTHONPATH=%PYTHONPATH%;%CD%\src
+# download and upgrade pip
+- ps: wget https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
+- python get-pip.py
+# install py.test
+- pip install pytest pep8
+
+test_script:
+# show environment
+- echo %path%
+- py.test --version
+# run tests
+- pep8 --ignore=E501 src/runtest.py
+- pep8 --ignore=E501 test/test.py
+- py.test -vv test/test.py

--- a/src/runtest.py
+++ b/src/runtest.py
@@ -270,11 +270,6 @@ def _parse_args(input_dir, argv):
                       help='log file [default: no logging]')
     (options, args) = parser.parse_args(args=argv[1:])
 
-    if sys.platform == "win32":
-        # on windows we flip possibly wrong slashes
-        options.binary_dir = string.replace(options.binary_dir, '/', '\\')
-        options.work_dir = string.replace(options.work_dir, '/', '\\')
-
     return options
 
 # ------------------------------------------------------------------------------

--- a/test/test.py
+++ b/test/test.py
@@ -74,12 +74,19 @@ def test_extract_numbers_mask():
 
 def test_parse_args():
 
-    input_dir = '/raboof/mytest'
-    argv = ['./test', '-b', '/raboof/build/']
+    if sys.platform == 'win32':
+        input_dir = '\raboof\mytest'
+        argv = ['test', '-b', '\raboof\build']
+    else:
+        input_dir = '/raboof/mytest'
+        argv = ['./test', '-b', '/raboof/build/']
 
     options = runtest._parse_args(input_dir, argv)
 
-    assert options == {'verbose': False, 'work_dir': '/raboof/mytest', 'binary_dir': '/raboof/build/', 'skip_run': False, 'debug': False, 'log': None}
+    if sys.platform == 'win32':
+        assert options == {'verbose': False, 'work_dir': '\raboof\mytest', 'binary_dir': '\raboof\build', 'skip_run': False, 'debug': False, 'log': None}
+    else:
+        assert options == {'verbose': False, 'work_dir': '/raboof/mytest', 'binary_dir': '/raboof/build/', 'skip_run': False, 'debug': False, 'log': None}
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
- adapted test.py for win32
- slight adaptation of runtest.py fix for Windows: do not replace path
  separators automatically, leave it to the user (cases problems for
  Python 3)
- adapting both python scripts to pep8 limits
- closes #7