### PR TITLE
Allow certain characters after number

### DIFF
--- a/runtest/extract.py
+++ b/runtest/extract.py
@@ -149,7 +149,7 @@ def test_extract_numbers_mask():
     ]
 
 
-def test_extract_numbers_mask():
+def test_extract_comma_separated_numbers_mask():
 
     text = """1.0, 2.0, 3.0, 4.0
 1.0, 2.0, 3.0, 4.0

--- a/runtest/extract.py
+++ b/runtest/extract.py
@@ -19,8 +19,8 @@ def extract_numbers(text, mask=None):
     # followed by optional exponent part if desired
     (?: [EeDd] [+-]? \d+ ) ?
     """
-
-    pattern_int = re.compile("^-?[0-9]+$", re.VERBOSE)
+    pattern_number = re.compile(r"^[0-9\.eEdD\+\-]+[\s,]*$", re.VERBOSE)
+    pattern_int = re.compile(r"^-?[0-9]+[\s,]*$", re.VERBOSE)
     pattern_float = re.compile(numeric_const_pattern, re.VERBOSE)
     pattern_d = re.compile(r"[dD]")
 
@@ -32,7 +32,7 @@ def extract_numbers(text, mask=None):
         for w in line.split():
             # do not consider words like TzB1g
             # otherwise we would extract 1 later
-            if re.match(r"^[0-9\.eEdD\+\-]*$", w):
+            if re.match(pattern_number, w):
                 i += 1
                 if mask is not None:
                     if i not in mask:
@@ -146,4 +146,23 @@ def test_extract_numbers_mask():
         (1, 12, 3),
         (2, 0, 3),
         (2, 12, 3),
+    ]
+
+
+def test_extract_numbers_mask():
+
+    text = """1.0, 2.0, 3.0, 4.0
+1.0, 2.0, 3.0, 4.0
+1.0, 2.0, 3.0, 4.0"""
+
+    numbers, locations = extract_numbers(text.splitlines(), mask=[1, 3])
+
+    assert numbers == [1.0, 3.0, 1.0, 3.0, 1.0, 3.0]
+    assert locations == [
+        (0, 0, 3),
+        (0, 10, 3),
+        (1, 0, 3),
+        (1, 10, 3),
+        (2, 0, 3),
+        (2, 10, 3),
     ]

--- a/runtest/extract.py
+++ b/runtest/extract.py
@@ -176,3 +176,28 @@ def test_extract_comma_separated_numbers_mask():
         (4, 0, 2),
         (4, 8, 2),
     ]
+
+
+def test_extract_separated_numbers_mask():
+
+    text = """1.0, 2.0' 3.0, 4.0
+1.0, 2.0- 3.0, 4.0
+1.0, 2.0? 3.0, 4.0
+12, 22' 32, 42
+12, 22- 32, 42"""
+
+    numbers, locations = extract_numbers(text.splitlines(), mask=[1, 3])
+
+    assert numbers == [1.0, 4.0, 1.0, 3.0, 1.0, 4.0, 12, 42, 12, 32]
+    assert locations == [
+        (0, 0, 3),
+        (0, 15, 3),
+        (1, 0, 3),
+        (1, 10, 3),
+        (2, 0, 3),
+        (2, 15, 3),
+        (3, 0, 2),
+        (3, 12, 2),
+        (4, 0, 2),
+        (4, 8, 2),
+    ]

--- a/runtest/extract.py
+++ b/runtest/extract.py
@@ -19,8 +19,8 @@ def extract_numbers(text, mask=None):
     # followed by optional exponent part if desired
     (?: [EeDd] [+-]? \d+ ) ?
     """
-    pattern_number = re.compile(r"^[0-9\.eEdD\+\-]+[,]?$", re.VERBOSE)
-    pattern_int = re.compile(r"^-?[0-9]+[,]?$", re.VERBOSE)
+    pattern_number_and_separator = re.compile(r"^[0-9\.eEdD\+\-]+[,]?$", re.VERBOSE)
+    pattern_int = re.compile(r"-?[0-9]+", re.VERBOSE)
     pattern_float = re.compile(numeric_const_pattern, re.VERBOSE)
     pattern_d = re.compile(r"[dD]")
 
@@ -28,28 +28,32 @@ def extract_numbers(text, mask=None):
     locations = []
 
     for n, line in enumerate(text):
-        i = 0
+        n_matches = 0
         for w in line.split():
             # do not consider words like TzB1g
-            # otherwise we would extract 1 later
-            if re.match(pattern_number, w):
-                i += 1
-                if mask is not None:
-                    if i not in mask:
-                        continue
-                is_integer = False
-                if len(pattern_float.findall(w)) > 0:
-                    is_integer = pattern_float.findall(w) == pattern_int.findall(w)
-                # apply floating point regex
-                for m in pattern_float.findall(w):
-                    index = line.index(m)
-                    # substitute dD by e
+            if not re.match(pattern_number_and_separator, w):
+                continue
+
+            n_matches += 1
+            if mask is not None and n_matches not in mask:
+                continue
+
+            is_integer = False
+            matched_floats = pattern_float.findall(w)
+
+            if len(matched_floats) > 0:
+                is_integer = matched_floats == pattern_int.findall(w)
+
+            # apply floating point regex
+            for m in matched_floats:
+                index = line.index(m)
+                # substitute dD by e
+                if is_integer:
+                    numbers.append(int(m))
+                else:
                     m = pattern_d.sub("e", m)
-                    if is_integer:
-                        numbers.append(int(m))
-                    else:
-                        numbers.append(float(m))
-                    locations.append((n, index, len(m)))
+                    numbers.append(float(m))
+                locations.append((n, index, len(m)))
 
     return numbers, locations
 
@@ -153,16 +157,22 @@ def test_extract_comma_separated_numbers_mask():
 
     text = """1.0, 2.0, 3.0, 4.0
 1.0, 2.0, 3.0, 4.0
-1.0, 2.0, 3.0, 4.0"""
+12, 22, 32, 42
+1.0, 2.0, 3.0, 4.0
+12, 22, 32, 42"""
 
     numbers, locations = extract_numbers(text.splitlines(), mask=[1, 3])
 
-    assert numbers == [1.0, 3.0, 1.0, 3.0, 1.0, 3.0]
+    assert numbers == [1.0, 3.0, 1.0, 3.0, 12, 32, 1.0, 3.0, 12, 32]
     assert locations == [
         (0, 0, 3),
         (0, 10, 3),
         (1, 0, 3),
         (1, 10, 3),
-        (2, 0, 3),
-        (2, 10, 3),
+        (2, 0, 2),
+        (2, 8, 2),
+        (3, 0, 3),
+        (3, 10, 3),
+        (4, 0, 2),
+        (4, 8, 2),
     ]

--- a/runtest/extract.py
+++ b/runtest/extract.py
@@ -19,8 +19,8 @@ def extract_numbers(text, mask=None):
     # followed by optional exponent part if desired
     (?: [EeDd] [+-]? \d+ ) ?
     """
-    pattern_number = re.compile(r"^[0-9\.eEdD\+\-]+[\s,]*$", re.VERBOSE)
-    pattern_int = re.compile(r"^-?[0-9]+[\s,]*$", re.VERBOSE)
+    pattern_number = re.compile(r"^[0-9\.eEdD\+\-]+[,]?$", re.VERBOSE)
+    pattern_int = re.compile(r"^-?[0-9]+[,]?$", re.VERBOSE)
     pattern_float = re.compile(numeric_const_pattern, re.VERBOSE)
     pattern_d = re.compile(r"[dD]")
 


### PR DESCRIPTION
I noticed that when extracting comma separated numbers only the last number is recognized. The reason for this is the following regex, which needs to match the entire word
```python
for w in line.split():
    if re.match(r"^[0-9\.eEdD\+\-]*$", w):
```

I fixed this by introducing `pattern_number_and_separator` which allows for a single `,` after a number. Additionally I needed to fix the integer pattern because that also needed to match the entire word.

I'm not sure if this is a good fix, maybe it is even intended to only match numbers separated by whitespace, but I wanted to propose my solution anyway. 
